### PR TITLE
Refactor LLM helper with conversation object

### DIFF
--- a/COMPONENT_DEVELOPMENT.md
+++ b/COMPONENT_DEVELOPMENT.md
@@ -40,3 +40,29 @@ config.register_config_item(
 
 Registered items appear in the **Configuration Center** page where their values can be edited through the UI.
 When using ``input_type='select'`` pass an ``options`` list to define the dropdown choices.
+
+## Interacting with the LLM
+
+Use the :class:`LLM` helper from ``utils`` for any language model requests:
+
+```python
+from utils import LLM
+
+llm = LLM()
+response = llm.ask("You are a helpful assistant.", "Hello")
+```
+
+For multi-turn interactions create a conversation instance and call ``send()``:
+
+```python
+conv = llm.create_conversation("You are a helpful assistant.")
+response = conv.send("Hello")
+```
+The object keeps track of the full history in ``conv.history``.
+You may override provider settings when instantiating the helper:
+
+```python
+llm = LLM(provider="openai", model_name="gpt-4")
+```
+Missing parameters fall back to values defined in `config.py`.
+

--- a/README.md
+++ b/README.md
@@ -22,5 +22,26 @@ The repository ships with only a simple example component.  Complex generators s
 ## Adding Components
 See [COMPONENT_DEVELOPMENT.md](COMPONENT_DEVELOPMENT.md) for information on building your own generators.
 
+## Using the LLM Helper
+Components can talk to the configured language model through the `LLM` class in `utils.py`.
+Create an instance and call `ask()` for a single response or start a `Conversation` for multi-turn chat.
+
+```python
+from utils import LLM
+
+llm = LLM()
+reply = llm.ask("You are a helpful assistant.", "Hello")
+```
+To hold a conversation create a `Conversation` instance and call `send()`:
+
+```python
+conv = llm.create_conversation("You are a helpful assistant.")
+reply = conv.send("Hello")
+```
+The conversation history is available via ``conv.history``.
+
+The constructor accepts optional `provider`, `api_key`, `base_url` and `model_name` parameters, falling back to configuration values.
+
+
 ## License
 Licensed under the Apache 2.0 License.

--- a/components/example_component.py
+++ b/components/example_component.py
@@ -1,20 +1,29 @@
 from component_base import BaseComponent
 import streamlit as st
 import utils
-import config
 
 
 class ExampleComponent(BaseComponent):
     name = "Echo Agent"
     description = "Demo agent that sends your prompt to the LLM and displays the response."
 
+    def __init__(self):
+        self.llm = utils.LLM()
+        if "example_conv" not in st.session_state:
+            st.session_state.example_conv = self.llm.create_conversation(
+                "You are a helpful assistant."
+            )
+
     def render(self):
         st.header(self.name)
         prompt = st.text_area("Prompt")
-        if st.button("Generate"):
+        if st.button("Send"):
             with st.spinner("Generating..."):
-                result = utils.askgpt("You are a helpful assistant.", prompt, config.GENERATION_MODEL)
-            st.text_area("Result", value=result, height=300)
+                reply = st.session_state.example_conv.send(prompt)
+        history_text = "\n".join(
+            f"{m['role']}: {m['content']}" for m in st.session_state.example_conv.history[1:]
+        )
+        st.text_area("Conversation", value=history_text, height=300)
 
 def get_component():
     return ExampleComponent()


### PR DESCRIPTION
## Summary
- add `create_conversation()` method and new `Conversation` class to manage chat history
- update example component to use a conversation instance
- revise docs to describe the new interface

## Testing
- `python -m py_compile utils.py components/example_component.py web.py component_manager.py component_base.py config.py log_writer.py`


------
https://chatgpt.com/codex/tasks/task_e_685d0ffdb9008330b232d7b20be8e285