### PR TITLE
Add image support in ask

### DIFF
--- a/COMPONENT_DEVELOPMENT.md
+++ b/COMPONENT_DEVELOPMENT.md
@@ -60,7 +60,12 @@ Use the :class:`LLM` helper from ``utils`` for any language model requests:
 from utils import LLM
 
 llm = LLM()
-response = llm.ask("You are a helpful assistant.", "Hello")
+response = llm.ask(
+    "You are a helpful assistant.",
+    "Describe this image",
+    image_path="example.png",
+)
+# Omit image_path for text-only prompts
 ```
 
 For multi-turn interactions create a conversation instance and call ``send()``:
@@ -97,7 +102,11 @@ def render(self):
     with tab_chat:
         prompt = st.text_area("Prompt")
         if st.button("Send"):
-            reply = self.llm.ask("You are a helpful assistant.", prompt)
+            reply = self.llm.ask(
+                "You are a helpful assistant.",
+                prompt,
+                image_path="example.png",
+            )
             st.write(reply)
 
     with tab_history:

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ Create an instance and call `ask()` for a single response or start a `Conversati
 from utils import LLM
 
 llm = LLM()
-reply = llm.ask("You are a helpful assistant.", "Hello")
+reply = llm.ask("You are a helpful assistant.", "Describe this image", image_path="example.png")
 ```
+Omit `image_path` for text-only prompts.
 To hold a conversation create a `Conversation` instance and call `send()`:
 
 ```python

--- a/utils.py
+++ b/utils.py
@@ -123,7 +123,7 @@ class LLM:
                 {"type": "text", "text": user_prompt},
                 {"type": "image_url", "image_url": {"url": image_url}},
             ]
-            user_message = HumanMessage(content=user_content)
+            user_message = HumanMessage(content=json.dumps(user_content))
         else:
             user_message = HumanMessage(content=user_prompt)
 

--- a/utils.py
+++ b/utils.py
@@ -38,6 +38,10 @@ def _create_client(provider: str, api_key: str, base_url: str, model_name: str):
 
 def _image_to_data_url(path: str) -> str:
     """Return the data URL for an image file."""
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"The file at path '{path}' does not exist.")
+    if not os.access(path, os.R_OK):
+        raise PermissionError(f"The file at path '{path}' is not readable.")
     mime, _ = mimetypes.guess_type(path)
     mime = mime or "image/png"
     with open(path, "rb") as f:


### PR DESCRIPTION
## Summary
- extend `LLM.ask` to accept an `image_path` and send a multi-modal message
- provide helper `_image_to_data_url`
- update `askgpt` wrapper
- document new parameter in README and COMPONENT_DEVELOPMENT

## Testing
- `python -m py_compile utils.py`

------
https://chatgpt.com/codex/tasks/task_e_685e6d983af883309927b08c91497392